### PR TITLE
Add the possibility to build the cldr data to have only one file per locale to download.

### DIFF
--- a/impl/common.js
+++ b/impl/common.js
@@ -254,7 +254,7 @@ define(["./List", "./Record",
 			 */
 			DefaultLocale : function () {
 				var result;
-				var global = (function (){return this;})();
+				var global = (function () {return this; })();
 				var navigator = global.navigator;
 				if (navigator && this.isStructurallyValidLanguageTag(navigator.language)) {
 					result = this.BestFitAvailableLocale(this.availableLocalesList, this

--- a/impl/load.js
+++ b/impl/load.js
@@ -13,7 +13,7 @@ define([
 	return {
 		id: module.id,
 
-		load: function (locale, callerRequire, onload) {
+		load: function (locale, callerRequire, onload, loaderConfig) {
 			// Compute dependencies to require().
 			// For specified locale, load JSON files for its "currencies", "numbers" data.
 			var jsonElements = ["currencies", "numbers"];
@@ -23,7 +23,7 @@ define([
 			supportedCalendars.forEach(function (calendar) {
 				var calendarName = "ca-" +  (calendar === "gregory" ? "gregorian" : calendar);
 				// Add json data
-					jsonElements.push(calendarName);
+				jsonElements.push(calendarName);
 				// Add calendar module
 				if (calendar !== "gregory") {
 					calendarsToLoad.push(calendar);
@@ -49,7 +49,7 @@ define([
 			dependencies = dependencies.concat(calendarDependencies);
 
 			// Load all the JSON files requested, and any non-gregorian calendars
-			// that are required.  Return the locale data in a hash
+			// that are required. Return the locale data in a hash
 			require(dependencies, function () {
 				var dataAsArray = arguments, dataAsHash = {};
 				jsonElements.forEach(function (element, idx) {

--- a/locales.js
+++ b/locales.js
@@ -69,29 +69,29 @@ define([
 			var modulesToAdd = [];
 			locales.forEach(function (locale) {
 				var localeData = localeDataHash[locale];
-				modulesToAdd = modulesToAdd.concat(localeData.calendars.map(function (cal){return "./calendars/" + cal;}));
+				var calendarsDeps = localeData.calendars.map(function (cal) {return "./calendars/" + cal; });
+				modulesToAdd = modulesToAdd.concat(calendarsDeps);
 				delete localeData.calendars;
 			});
 			addModules(modulesToAdd);
 		},
 
 		onLayerEnd: function (write, data) {
-			function getLayerPath(data, loc) {
-				var match = data.path.match(/^(.*\/)?(.*)\.js$/);
-				return (match[1] || "") + "cldr/" + match[2] + "_" + loc + ".js";
-			}
-			function getLayerMid(data) {
-				var match = data.name.match(/^(.*\/)?(.*)$/);
-				return (match[1] || "") + "cldr/" + match[2];
-			}
+			// Calculate layer path
+			var match = data.path.match(/^(.*\/)?(.*)\.js$/);
+			var partialLayerPath = (match[1] || "") + "cldr/" + match[2] + "_";
+
+			// Calculate layer mid
+			match = data.name.match(/^(.*\/)?(.*)$/);
+			var layerMid = (match[1] || "") + "cldr/" + match[2];
 
 			locales.forEach(function (locale) {
-				var path = getLayerPath(data, locale);
+				var path = partialLayerPath + locale + ".js";
 				writeFile(path, "define(" + JSON.stringify(localeDataHash[locale]) + ")");
 			});
 
-			localeHash._layerMid = getLayerMid(data);
-			write("require.config({config:{'" + loadCss.id + "':" + JSON.stringify(localeHash) + "}});")
+			localeHash._layerMid = layerMid;
+			write("require.config({config:{'" + loadCss.id + "':" + JSON.stringify(localeHash) + "}});");
 
 			// Reset
 			localeDataHash = {};


### PR DESCRIPTION
This PR add support for the build of cldr data.

Running a build will generate a cldr layer for each locale specified. The system to configure the locales to build is the same than the one used to preload locales at runtime.

The layer will contains all the json files required by `ecma402/impl/load` and the calendar modules will be added to the regular js layer. 

The code in `ecma402/locales.js` is responsible for writing the layers while the code in `ecma402/load.js` is responsible for picking the right layer if one is available.
