### PR TITLE
default config for locales to build is now all the available locales

### DIFF
--- a/locales.js
+++ b/locales.js
@@ -49,7 +49,15 @@ define([
 	}
 
 	return {
-		load: function (path, callerRequire, onload) {
+		load: function (path, callerRequire, onload, loaderConfig) {
+			if (config instanceof Object && loaderConfig.isBuild) {
+				localeHash = {};
+				common.availableLocalesList.forEach(function (locale) {
+					localeHash[locale] = true;
+				});
+				locales = Object.keys(localeHash);
+			}
+
 			var dependencies = locales.map(getDependency);
 			// Load the locale data for every requested locale, and then return it in a hash
 			require(dependencies, function () {


### PR DESCRIPTION
This change allows to omit `ecma402/locales` config if you want to build all the locales.
Since we are at build time it is not a problem to load all the locales data.
