### PR TITLE
Fix comma separation and currency symbol for Nepal

### DIFF
--- a/cldr/ne/currencies.json
+++ b/cldr/ne/currencies.json
@@ -409,7 +409,7 @@
           },
           "NPR": {
             "displayName": "नेपाली रूपैयाँ",
-            "symbol": "नेरू"
+            "symbol": "रू"
           },
           "NZD": {
             "displayName": "न्यूजिल्याण्ड डलर",

--- a/cldr/ne/numbers.json
+++ b/cldr/ne/numbers.json
@@ -20,22 +20,22 @@
           "nan": "NaN"
         },
         "decimalFormats-numberSystem-deva": {
-          "standard": "#,##0.###"
+          "standard": "#,##,##0.###"
         },
         "decimalFormats-numberSystem-latn": {
-          "standard": "#,##0.###"
+          "standard": "#,##,##0.###"
         },
         "percentFormats-numberSystem-deva": {
-          "standard": "#,##0%"
+          "standard": "#,##,##0%"
         },
         "percentFormats-numberSystem-latn": {
-          "standard": "#,##0%"
+          "standard": "#,##,##0%"
         },
         "currencyFormats-numberSystem-deva": {
-          "standard": "¤ #,##0.00"
+          "standard": "¤ #,##,##0.00"
         },
         "currencyFormats-numberSystem-latn": {
-          "standard": "¤ #,##0.00"
+          "standard": "¤ #,##,##0.00"
         }
       }
     }


### PR DESCRIPTION
The number separation in Nepal is similar to its neighbor country India. They are in ones, tens, hundreds, thousands, ten thousands, lakhs, ten lakhs ...
e.g: **1,00,00,00,000**

The currency in Nepal is Rupees which is denoted by **रू**.
e.g: **रू 1,00,00,00,000**
for reference: [Nepal Number System](http://www.nepaliclass.com/large-nepali-numbers-lakh-karod-arab-kharab/)